### PR TITLE
BUG: kwargs were not passed correctly to `ShellCommand`.

### DIFF
--- a/lancet/launch.py
+++ b/lancet/launch.py
@@ -170,10 +170,10 @@ class ShellCommand(Command):
 
         options = []
         for (k, v) in expanded.items():
-            if k in self.posargs or spec[k] == False:
+            if k in self.posargs or spec[k] is False:
                 continue
             options.append('%s%s' % (self.long_prefix if len(k) > 1 else self.short_prefix, k))
-            if spec[k] != True:
+            if spec[k] is not True:
                 options.append(v)
 
         posargs = [expanded[parg] if (parg in expanded) else parg(spec, info, tid)

--- a/tests/test_shell_command.py
+++ b/tests/test_shell_command.py
@@ -1,0 +1,46 @@
+
+from collections import OrderedDict
+from unittest import TestCase, main
+
+from lancet import ShellCommand
+
+
+class TestShellCommand(TestCase):
+    def test_kwargs_are_passed_correctly(self):
+        # Given
+        sc = ShellCommand('test.py')
+
+        # When
+        spec = OrderedDict(arg1=0, arg2=1)
+
+        # Then
+        cmd_line = sc(spec)
+        expected = ['test.py', '--arg1', '0', '--arg2', '1']
+        self.assertEqual(cmd_line, expected)
+
+    def test_kwargs_with_true_value_is_passed_correctly(self):
+        # Given
+        sc = ShellCommand('test.py')
+
+        # When
+        spec = OrderedDict(arg=True)
+
+        # Then
+        cmd_line = sc(spec)
+        expected = ['test.py', '--arg']
+        self.assertEqual(cmd_line, expected)
+
+    def test_kwargs_with_false_value_is_not_passed(self):
+        # Given
+        sc = ShellCommand('test.py')
+
+        # When
+        spec = OrderedDict(arg=False)
+
+        # Then
+        cmd_line = sc(spec)
+        expected = ['test.py']
+        self.assertEqual(cmd_line, expected)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The checks for the value of the key was checked with equality and not
identity leading to incorrect behavior.  Added simple tests for this.