### PR TITLE
Fixed to_table function to match new holoviews column signature

### DIFF
--- a/lancet/core.py
+++ b/lancet/core.py
@@ -36,9 +36,11 @@ def to_table(args, vdims=[]):
     "Helper function to convet an Args object to a HoloViews Table"
     if not Table:
         return "HoloViews Table not available"
-    kdims = args.constant_keys + args.varying_keys
-    items = ((tuple([spec[k] for k in kdims]), ()) for spec in args.specs)
-    return Table(items, kdims=kdims, vdims=[]).reindex(None, vdims)
+    kdims = [dim for dim in args.constant_keys + args.varying_keys
+             if dim not in vdims]
+    items = [tuple([spec[k] for k in kdims+vdims])
+             for spec in args.specs]
+    return Table(items, kdims=kdims, vdims=vdims)
 
 #=====================#
 # Argument Specifiers #


### PR DESCRIPTION
The current ``to_table`` function constructs the holoviews Table in a deprecated format. This updates it to the simpler list of tuple format.