### PR TITLE
QLauncher data pickled with protocol 2

### DIFF
--- a/lancet/launch.py
+++ b/lancet/launch.py
@@ -791,7 +791,7 @@ class QLauncher(Launcher):
         # Pickle launcher before exit if necessary.
         if self.dynamic or (self.reduction_fn is not None):
             pickle_path = os.path.join(self.root_directory, 'qlauncher.pkl')
-            pickle.dump(self, open(pickle_path,'wb'))
+            pickle.dump(self, open(pickle_path,'wb'), protocol=2)
 
     def _qsub_collate_and_launch(self, output_dir, error_dir, job_names):
         """


### PR DESCRIPTION
As the title says, this ensures that the QLauncher data is pickled with the highest available protocol. The default protocol (0) is slow and I have frequently encountered issues pickling certain objects, particularly involving C(++) extensions and some objects using ``__slots__``. 

Defaulting to the highest available protocol would gain size/speed benefits and address the issues pickling certain complex objects with little effect on backward compatibility. In Python 2 it would use protocol 2 (introduced in Python 2.3) and in Python 3 it would use protocol 3 or 4. If we want to keep support between Python3 and Python2, we could also consider setting it to 2.