### PR TITLE
py3.5 fix

### DIFF
--- a/lancet/core.py
+++ b/lancet/core.py
@@ -973,7 +973,9 @@ class FileInfo(Args):
 
             mdata = dict((k,v) for (k,v) in filetype.metadata(spec[key]).items()
                          if k not in ignore)
-            mdata_spec = dict(spec, **mdata)
+            mdata_spec = {}
+            mdata_spec.update(spec)
+            mdata_spec.update(mdata)
             specs.append(mdata_spec)
             mdata_clashes = mdata_clashes | (set(spec.keys()) & set(mdata.keys()))
         # Metadata clashes can be avoided by using the ignore list.


### PR DESCRIPTION
Fixes this error from using code valid in python2 but not python 3.5:

```
0172-jbednar:~/param> python
Python 3.5.2 |Continuum Analytics, Inc.| (default, Jul  2 2016, 17:52:12) 
[GCC 4.2.1 Compatible Apple LLVM 4.2 (clang-425.0.28)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import lancet
>>> example_name   = 'prime_quintuplet'
>>> integers       = lancet.Range('integer', 100, 115, steps=16, fp_precision=0)
>>> factor_cmd     = lancet.ShellCommand(executable='gfactor', posargs=['integer'])
>>> lancet.Launcher(example_name, integers, factor_cmd, output_directory='output')()
INFO:root:Launcher: Group 0: executing 16 processes...
>>> def load_factors(filename):
   "Return output of 'factor' command as dictionary of factors."
   with open(filename, 'r') as f:
       factor_list = f.read().replace(':', '').split()
   return dict(enumerate(int(el) for el in factor_list))
>>> output_files   = lancet.FilePattern('filename', './output/*-prime*/streams/*.o*')
>>> output_factors = lancet.FileInfo(output_files, 'filename', lancet.CustomFile(metadata_fn=load_factors))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jbednar/anaconda/envs/datashader-docs/lib/python3.5/site-packages/lancet/core.py", line 874, in __init__
    specs = self._info(source, key, filetype, ignore)
  File "/Users/jbednar/anaconda/envs/datashader-docs/lib/python3.5/site-packages/lancet/core.py", line 976, in _info
    mdata_spec = dict(spec, **mdata)
TypeError: keyword arguments must be strings
```